### PR TITLE
Migrate API domain to api.frgmt.xyz

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # Claude FAQ API
 
-Base URL: `https://api.kcodes.me/claude-faqs/v1`
+Base URL: `https://api.frgmt.xyz/claude-faqs/v1`
 
 This API serves the markdown FAQ corpus as structured JSON for bots and internal tools.
 
@@ -17,7 +17,7 @@ Example:
 
 ```bash
 curl -H "Authorization: Bearer cfaq_your_key_here" \
-  https://api.kcodes.me/claude-faqs/v1/categories
+  https://api.frgmt.xyz/claude-faqs/v1/categories
 ```
 
 ## Rate-limit headers
@@ -118,7 +118,7 @@ Example:
 
 ```bash
 curl -H "Authorization: Bearer cfaq_your_key_here" \
-  "https://api.kcodes.me/claude-faqs/v1/entries?category=billing&limit=5"
+  "https://api.frgmt.xyz/claude-faqs/v1/entries?category=billing&limit=5"
 ```
 
 Summary entries include:
@@ -158,7 +158,7 @@ Example:
 
 ```bash
 curl -H "Authorization: Bearer cfaq_your_key_here" \
-  "https://api.kcodes.me/claude-faqs/v1/search?q=billing+refund&mode=semantic"
+  "https://api.frgmt.xyz/claude-faqs/v1/search?q=billing+refund&mode=semantic"
 ```
 
 Default response shape:
@@ -196,7 +196,7 @@ Example:
 
 ```bash
 curl -H "Authorization: Bearer cfaq_your_key_here" \
-  https://api.kcodes.me/claude-faqs/v1/account-banned
+  https://api.frgmt.xyz/claude-faqs/v1/account-banned
 ```
 
 If the slug does not exist, the API returns a 404 with `did_you_mean` suggestions.
@@ -238,7 +238,7 @@ Input options:
 
 ```bash
 curl -H "Authorization: Bearer cfaq_your_key_here" \
-  "https://api.kcodes.me/claude-faqs/v1/ask?q=how+do+I+request+a+refund"
+  "https://api.frgmt.xyz/claude-faqs/v1/ask?q=how+do+I+request+a+refund"
 ```
 
 or
@@ -248,7 +248,7 @@ curl -X POST \
   -H "Authorization: Bearer cfaq_your_key_here" \
   -H "Content-Type: application/json" \
   -d '{"question":"how do I request a refund"}' \
-  https://api.kcodes.me/claude-faqs/v1/ask
+  https://api.frgmt.xyz/claude-faqs/v1/ask
 ```
 
 Response shape:

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,8 +4,8 @@ compatibility_date = "2026-03-10"
 workers_dev = true
 
 [[routes]]
-pattern = "api.kcodes.me/claude-faqs/*"
-zone_name = "kcodes.me"
+pattern = "api.frgmt.xyz"
+custom_domain = true
 
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

Migrates the public API hostname from `api.kcodes.me` to `api.frgmt.xyz`, switches the Worker route to a Cloudflare custom domain, and updates the docs to match. Worker is already deployed and verified live on the new domain.

## What changed

- [ ] Added a new FAQ
- [ ] Improved an existing answer
- [ ] Updated outdated sources or verification dates
- [x] Changed parser, search, or Worker behavior
- [x] Updated contributor docs or templates

## Files touched

- `wrangler.toml` — replaced the path-based route on `api.kcodes.me/claude-faqs/*` with a `custom_domain = true` binding on `api.frgmt.xyz` (zone is auto-detected from the hostname). Custom domain auto-provisions DNS, avoiding the AAAA placeholder dance required for path routes.
- `docs/API.md` — updated all 7 base-URL references in headings and curl examples.

## Source check

- [x] I used official Anthropic sources where the answer is time-sensitive
- [x] I noted clearly when Anthropic does not document something publicly

(N/A — no FAQ content changes.)

## Validation

- [ ] `bun run check:faq`
- [ ] `bun run build:faq`
- [ ] `bun run typecheck`

Live-traffic validation against the new domain after deploy:

- `GET https://api.frgmt.xyz/claude-faqs/v1/` — 200, metadata correct
- `GET .../search?q=refund` — 200, returns expected billing/refund matches
- `GET .../categories` without auth — 401 as expected

## Notes for reviewer

- The custom-domain switch means the entire `api.frgmt.xyz` hostname is now owned by this Worker. If you ever want to host a different Worker at another path on the same hostname, you'd need to revert to a route + DNS placeholder.
- `WALL_OF_FAME.md` still references `@kcodes0` — that's the GitHub handle, not the domain, so left untouched.
- Pre-existing doc bug (not fixed here): the example in `docs/API.md` uses slug `account-banned` but the actual built slug is `account-was-banned`.